### PR TITLE
update to gnome 47 platform

### DIFF
--- a/cafe.avery.Delfin.yaml
+++ b/cafe.avery.Delfin.yaml
@@ -1,10 +1,10 @@
 app-id: cafe.avery.Delfin
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "47"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-  - org.freedesktop.Sdk.Extension.llvm16
+  - org.freedesktop.Sdk.Extension.llvm18
 
 command: delfin
 
@@ -21,7 +21,7 @@ finish-args:
   - --socket=pulseaudio
 
 build-options:
-  append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin"
+  append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin"
   env:
     CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
@@ -43,23 +43,22 @@ modules:
       - -Dmanpage-build=disabled
       - -Dlibarchive=enabled
       - -Dsdl2=enabled
-      - -Dshaderc=enabled
       - -Dvulkan=enabled
     cleanup:
       - /include
       - /lib/pkgconfig
     sources:
       - type: archive
-        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz
-        sha256: 1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf
+        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.39.0.tar.gz
+        sha256: 2ca92437affb62c2b559b4419ea4785c70d023590500e8a52e95ea3ab4554683
     modules:
       - name: libXmu
         buildsystem: autotools
         sources:
           - type: git
             url: https://gitlab.freedesktop.org/xorg/lib/libxmu.git
-            tag: libXmu-1.1.4
-            commit: b29c739b577ee142877e69eb3fb07c7312d81557
+            tag: libXmu-1.2.1
+            commit: 792f80402ee06ce69bca3a8f2a84295999c3a170
             x-checker-data:
               type: git
               tag-pattern: ^libXmu-([\d.]+)$
@@ -139,8 +138,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/libass/libass.git
-            tag: 0.17.1
-            commit: e8ad72accd3a84268275a9385beb701c9284e5b3
+            tag: 0.17.3
+            commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
             x-checker-data:
               type: git
               tag-pattern: ^(\d\.\d{1,3}\.\d{1,2})$
@@ -174,8 +173,8 @@ modules:
             url: https://github.com/breakfastquay/rubberband.git
             mirror-urls:
               - https://hg.sr.ht/~breakfastquay/rubberband
-            tag: v3.3.0
-            commit: 2be46b0dffb13273a67396c77bc9278736bb03d2
+            tag: v4.0.0
+            commit: 1d95888bec3ae0a17c0c4af791810d5a63f6bc35
             x-checker-data:
               type: git
               tag-pattern: ^v([\d.]+)$
@@ -197,8 +196,8 @@ modules:
             url: https://github.com/ccxvii/mujs.git
             mirror-urls:
               - http://git.ghostscript.com/mujs.git
-            tag: 1.3.4
-            commit: a76d157bdaa9aec8de5ea5a362eed2f59139152d
+            tag: 1.3.6
+            commit: cc569c5fa9a7a2498177693b5617605c2ff5b260
             x-checker-data:
               type: git
               url: https://api.github.com/repos/ccxvii/mujs/tags
@@ -215,8 +214,8 @@ modules:
             url: https://github.com/FFmpeg/nv-codec-headers.git
             mirror-urls:
               - https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
-            tag: n12.1.14.0
-            commit: 1889e62e2d35ff7aa9baca2bceb14f053785e6f1
+            tag: n13.0.19.0
+            commit: e844e5b26f46bb77479f063029595293aa8f812d
             x-checker-data:
               type: git
               tag-pattern: ^n([\d.]+)$
@@ -255,8 +254,8 @@ modules:
         sources:
           - type: git
             url: https://bitbucket.org/multicoreware/x265_git.git
-            tag: "3.5"
-            commit: f0c1022b6be121a753ff02853fbe33da71988656
+            tag: "4.1"
+            commit: 1d117bed4747758b51bd2c124d738527e30392cb
             x-checker-data:
               type: git
               tag-pattern: ^([\d.]+)$
@@ -305,8 +304,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/libjxl/libjxl.git
-            tag: v0.9.1
-            commit: b8ceae3a6e9d0ffd9efebcbdd04322fcfc502eed
+            tag: v0.11.1
+            commit: 794a5dcf0d54f9f0b20d288a12e87afb91d20dfc
             disable-shallow-clone: true
             x-checker-data:
               type: git
@@ -347,8 +346,8 @@ modules:
             url: https://github.com/FFmpeg/FFmpeg.git
             mirror-urls:
               - https://git.ffmpeg.org/ffmpeg.git
-            commit: e38092ef9395d7049f871ef4d5411eb410e283e0
-            tag: n6.1.1
+            commit: db69d06eeeab4f46da15030a80d539efb4503ca8
+            tag: n7.1.1
             x-checker-data:
               type: git
               tag-pattern: ^n([\d.]{3,7})$
@@ -361,8 +360,8 @@ modules:
         sources:
           - type: archive
             archive-type: tar
-            url: https://api.github.com/repos/libsixel/libsixel/tarball/refs/tags/v1.10.3
-            sha256: 7be774befba882d53701e131b6657836118f6cdb15a7515f92345c7bb6e2bb5c
+            url: https://api.github.com/repos/libsixel/libsixel/tarball/refs/tags/v1.10.5
+            sha256: 402da9e24caea62fe1e4c5d6f9c9211141f7a5d8016e717527ecde10c5522344
             x-checker-data:
               type: json
               url: https://api.github.com/repos/libsixel/libsixel/tags
@@ -376,8 +375,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/vapoursynth/vapoursynth.git
-            tag: R65
-            commit: 3157049549a0940359b37004aeeeebd8f1db665e
+            tag: R70
+            commit: 03c8b6719f202b162284f53efc5b50632f70f72e
             x-checker-data:
               type: git
               tag-pattern: ^R([\d.]+)$
@@ -395,8 +394,8 @@ modules:
             url: https://code.videolan.org/videolan/libplacebo.git
             mirror-urls:
               - https://github.com/haasn/libplacebo.git
-            tag: v6.338.2
-            commit: 64c1954570f1cd57f8570a57e51fb0249b57bb90
+            tag: v7.349.0
+            commit: 1fd3c7bde7b943fe8985c893310b5269a09b46c5
             x-checker-data:
               type: git
               tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
had to disable shaderc for mpv since it now requires the `win32-desktop` feature